### PR TITLE
Fix links to grey Penrose images

### DIFF
--- a/pages/texture.html
+++ b/pages/texture.html
@@ -40,7 +40,7 @@ tags:
         <div class="penrose-grey-2-color">
           <h2>Grey 2-color</h2>
         </div>
-        <p class="file-links"><span class="file-link-label">Rectangle:</span> <a href="/assets/img/content/penrose/penrose-green-2-color-rect@2x.png">2x</a> | <a href="/assets/img/content/penrose/penrose-green-2-color-rect@1x.png">1x</a> | <a href="/assets/img/content/penrose/penrose-green-2-color-rect@0.5x.png">0.5x</a> <span class="file-link-label">Full:</span> <a href="/assets/img/content/penrose/penrose-green-2-color.png">1x</a></p>
+        <p class="file-links"><span class="file-link-label">Rectangle:</span> <a href="/assets/img/content/penrose/penrose-grey-2-color-rect@2x.png">2x</a> | <a href="/assets/img/content/penrose/penrose-grey-2-color-rect@1x.png">1x</a> | <a href="/assets/img/content/penrose/penrose-grey-2-color-rect@0.5x.png">0.5x</a> <span class="file-link-label">Full:</span> <a href="/assets/img/content/penrose/penrose-grey-2-color.png">1x</a></p>
 
       </dd>
       <dd class="green">
@@ -54,7 +54,7 @@ tags:
         <div class="penrose-grey-subdued">
           <h2>Grey Subdued</h2>
         </div>
-        <p class="file-links"><span class="file-link-label">Rectangle:</span> <a href="/assets/img/content/penrose/penrose-green-subdued-rect@2x.png">2x</a> | <a href="/assets/img/content/penrose/penrose-green-subdued-rect@1x.png">1x</a> | <a href="/assets/img/content/penrose/penrose-green-subdued-rect@0.5x.png">0.5x</a> <span class="file-link-label">Full:</span> <a href="/assets/img/content/penrose/penrose-green-subdued.png">1x</a></p>
+        <p class="file-links"><span class="file-link-label">Rectangle:</span> <a href="/assets/img/content/penrose/penrose-grey-subdued-rect@2x.png">2x</a> | <a href="/assets/img/content/penrose/penrose-grey-subdued-rect@1x.png">1x</a> | <a href="/assets/img/content/penrose/penrose-grey-subdued-rect@0.5x.png">0.5x</a> <span class="file-link-label">Full:</span> <a href="/assets/img/content/penrose/penrose-grey-subdued.png">1x</a></p>
 
       </dd>
       <dd>
@@ -68,7 +68,7 @@ tags:
         <div class="penrose-grey-stroke">
           <h2>Grey Stroke</h2>
         </div>
-        <p class="file-links"><span class="file-link-label">Rectangle:</span> <a href="/assets/img/content/penrose/penrose-green-stroke-rect@2x.png">2x</a> | <a href="/assets/img/content/penrose/penrose-green-stroke-rect@1x.png">1x</a> | <a href="/assets/img/content/penrose/penrose-green-stroke-rect@0.5x.png">0.5x</a> <span class="file-link-label">Full:</span> <a href="/assets/img/content/penrose/penrose-green-stroke.png">1x</a></p>
+        <p class="file-links"><span class="file-link-label">Rectangle:</span> <a href="/assets/img/content/penrose/penrose-grey-stroke-rect@2x.png">2x</a> | <a href="/assets/img/content/penrose/penrose-grey-stroke-rect@1x.png">1x</a> | <a href="/assets/img/content/penrose/penrose-grey-stroke-rect@0.5x.png">0.5x</a> <span class="file-link-label">Full:</span> <a href="/assets/img/content/penrose/penrose-grey-stroke.png">1x</a></p>
 
       </dd>
     </dl>


### PR DESCRIPTION
<!-- If fixing a bug, add `?template=BUG.md` to the end of the URL to use that template instead -->
<!-- If changing only documentation, add `?template=DOCUMENTATION.md` to the end of the URL to use that template instead -->

### Closes #XXXX

<!-- If only part of a change, use Part of #XXXX instead -->

<!-- summarize the problem described in the related issue -->

### Proposed changes:

- Update links that should point to _grey_ Penrose images that currently point to _green_ ones.
-

<!-- Add detailed discussion of changes here -->
<!-- Insert screenshots if needed (drag images here) -->

### Acceptance criteria validation

<!-- Were you able to fully test the acceptance criteria on the related ticket? -->

- [ ] Fulfilled Acceptance Criteria

  <!-- If not, why not? -->

- [ ] Tests added to cover the change
  <!-- If not, why not? -->

### Optional Details

#### Alternate Designs

<!-- Explain what other alternatives were considered and why the proposed version was selected -->

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

#### Security implications

<!-- What are the potential security concerns? Does the change deal with PII? User input? A component with a known vulnerability? Etc. -->

#### Requested feedback

<!-- What type of feedback would you like from reviewers? -->
